### PR TITLE
Implement snmpwalk to find all available disks and storages rather than looping through a hardcoded maximum number and checking the result for an error

### DIFF
--- a/check_synology.py
+++ b/check_synology.py
@@ -140,7 +140,7 @@ if mode == 'storage':
             if critical and critical < int(storage_used_percent):
                 state = 'CRITICAL'
 
-            output += ' -  free space: ' + storage_name + ' ' + str(storage_free) + ' GB (' + str(storage_used) + ' GB von ' + str(storage_size) + ' GB belegt, ' + str(storage_used_percent) + '%)'
+            output += ' -  free space: ' + storage_name + ' ' + str(storage_free) + ' GB (' + str(storage_used) + ' GB of ' + str(storage_size) + ' GB used, ' + str(storage_used_percent) + '%)'
             perfdata += storage_name + '=' + str(storage_used) + 'c '
     print('%s%s %s' % (state, output, perfdata))
     exitCode()

--- a/check_synology.py
+++ b/check_synology.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from pysnmp.hlapi import *
 import argparse
 import sys
@@ -44,9 +46,8 @@ def snmpget(oid):
                             errorIndex and varBinds[int(errorIndex) - 1][0] or '?'))
     else:
         for varBind in varBinds:
-            answer = (' = '.join([x.prettyPrint() for x in varBind]))
-            #print(' = '.join([x.prettyPrint() for x in varBind]))
-            return x.prettyPrint()
+            #answer = (' = '.join([x.prettyPrint() for x in varBind]))
+            return varBind[-1].prettyPrint()
 
 def exitCode():
     if state == 'OK':
@@ -68,7 +69,7 @@ if mode == 'load':
     if critical and critical < int(math.ceil(float(load1))):
         state = 'CRITICAL'
 
-    print state + ' - load average: %s, %s, %s' % (load1, load5, load15), '| load1=%sc' % load1, 'load5=%sc' % load5, 'load15=%sc' % load15
+    print(state + ' - load average: %s, %s, %s' % (load1, load5, load15), '| load1=%sc' % load1, 'load5=%sc' % load5, 'load15=%sc' % load15)
     exitCode()
 
 if mode == 'memory':
@@ -81,7 +82,7 @@ if mode == 'memory':
     if critical and critical > int(memory_percent):
         state = 'CRITICAL'
 
-    print state + ' - {:0.1f}% '.format(memory_percent) + 'free ({0:0.1f} MB out of {1:0.1f} MB)'.format((memory_unused / 1024), (memory_total / 1024)), '|memory_total=%dc' % memory_total, 'memory_unused=%dc' % memory_unused , 'memory_percent=%d' % memory_percent + '%'
+    print(state + ' - {:0.1f}% '.format(memory_percent) + 'free ({0:0.1f} MB out of {1:0.1f} MB)'.format((memory_unused / 1024), (memory_total / 1024)), '|memory_total=%dc' % memory_total, 'memory_unused=%dc' % memory_unused , 'memory_percent=%d' % memory_percent + '%')
     exitCode()
 
 if mode == 'disk':
@@ -115,7 +116,7 @@ if mode == 'disk':
 
         output += ' - ' + disk_name + ': Status: ' + disk_status + ', Temperature: ' + disk_temp + ' C'
         perfdata += 'temperature' + disk_name + '=' + disk_temp + 'c '
-    print '%s%s %s' % (state, output, perfdata)
+    print('%s%s %s' % (state, output, perfdata))
     exitCode()
 
 if mode == 'storage':
@@ -141,7 +142,7 @@ if mode == 'storage':
 
             output += ' -  free space: ' + storage_name + ' ' + str(storage_free) + ' GB (' + str(storage_used) + ' GB von ' + str(storage_size) + ' GB belegt, ' + str(storage_used_percent) + '%)'
             perfdata += storage_name + '=' + str(storage_used) + 'c '
-    print '%s%s %s' % (state, output, perfdata)
+    print('%s%s %s' % (state, output, perfdata))
     exitCode()
 
 if mode == 'update':
@@ -161,7 +162,7 @@ if mode == 'update':
         state = 'CRITICAL'
 
     update_status = status_translation.get(update_status_nr)
-    print state + ' - DSM Version: %s, DSM Update: %s' % (update_dsm_verison, update_status), '| DSMupdate=%sc' % update_status_nr
+    print(state + ' - DSM Version: %s, DSM Update: %s' % (update_dsm_verison, update_status), '| DSMupdate=%sc' % update_status_nr)
     exitCode()
 
 if mode == 'status':
@@ -189,5 +190,5 @@ if mode == 'status':
     if critical and critical < int(status_temperature):
         state = 'CRITICAL'
 
-    print state + ' - Model: %s, S/N: %s, System Temperature: %s C, System Status: %s, System Fan: %s, CPU Fan: %s, Powersupply : %s' % (status_model, status_serial, status_temperature, status_system, status_system_fan, status_cpu_fan, status_power) + ' | system_temp=%sc' % status_temperature
+    print(state + ' - Model: %s, S/N: %s, System Temperature: %s C, System Status: %s, System Fan: %s, CPU Fan: %s, Powersupply : %s' % (status_model, status_serial, status_temperature, status_system, status_system_fan, status_cpu_fan, status_power) + ' | system_temp=%sc' % status_temperature)
     exitCode()


### PR DESCRIPTION
Currently, the script loops through 256 possible OIDs to find out if any of them represents a storage. The better way to detect all storages available is to let the snmp daemon on the synology return which storages are available (i.e. do a snmp walk of OID 1.3.6.1.2.1.25.2.3.1.3 rather than explicitly checking all possible OIDs). This way, there will be much less snmp calls to the synology.

This patch also adds some fixes for Python3 (print needs parentheses) and fixes some German messages.