### PR TITLE
Include cached memory into usable memory calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Available modes:
 | mode    | description                                                                | warning/critical                    |
 | :-----: | -------------------------------------------------------------------------- | ----------------------------------- |
 | load    | Checks the load1, load5 and load15 values                                  | if more than w/c in int (only load1)|
-| memory  | Checks the physical installed memory (free and total)                      | if less free than w/c in %          |
+| memory  | Checks the physical installed memory (unused, cached and total)            | if less usable than w/c in %        |
 | disk    | Detects and checks all disks (name, status, temperature)                   | if temp higher than w/c in °C <br> if c is set it will also trigger if status <br> is Failure or Crashed                                                             |
 | storage | Detects and checks all disks (free, total, %)                              | if more used than w/c in %          |
 | update  | Shows the current DSM version and if DSM update is available               | set w/c to any int this triggers: <br> warning if available and critical <br> if other than un-/available                                                           |

--- a/check_synology.py
+++ b/check_synology.py
@@ -76,17 +76,17 @@ if mode == 'load':
 
 if mode == 'memory':
     memory_total = float(snmpget('1.3.6.1.4.1.2021.4.5.0'))
-    memory_avail = float(snmpget('1.3.6.1.4.1.2021.4.6.0'))
+    memory_unused = float(snmpget('1.3.6.1.4.1.2021.4.6.0'))
     memory_cached = float(snmpget('1.3.6.1.4.1.2021.4.15.0'))
-    memory_unused = memory_avail + memory_cached
-    memory_percent = 100 / memory_total * memory_unused
+    memory_usable = memory_unused + memory_cached
+    memory_percent = 100 / memory_total * memory_usable
 
     if warning and warning > int(memory_percent):
         state = 'WARNING'
     if critical and critical > int(memory_percent):
         state = 'CRITICAL'
 
-    print(state + ' - {:0.1f}% '.format(memory_percent) + 'free ({0:0.1f} MB out of {1:0.1f} MB)'.format((memory_unused / 1024), (memory_total / 1024)), '|memory_total=%dc' % memory_total, 'memory_unused=%dc' % memory_unused , 'memory_percent=%d' % memory_percent + '%')
+    print(state + ' - {:0.1f}% '.format(memory_percent) + 'usable ({0:0.1f} MB free and {1:0.1f} MB cached out of {2:0.1f} MB)'.format((memory_unused / 1024), (memory_cached / 1024), (memory_total / 1024)), '|memory_total=%dc' % memory_total, 'memory_unused=%dc' % memory_unused, 'memory_cached=%dc' % memory_cached, 'memory_usable=%dc' % memory_usable, 'memory_percent=%d' % memory_percent + '%')
     exitCode()
 
 if mode == 'disk':

--- a/check_synology.py
+++ b/check_synology.py
@@ -76,7 +76,9 @@ if mode == 'load':
 
 if mode == 'memory':
     memory_total = float(snmpget('1.3.6.1.4.1.2021.4.5.0'))
-    memory_unused = float(snmpget('1.3.6.1.4.1.2021.4.6.0'))
+    memory_avail = float(snmpget('1.3.6.1.4.1.2021.4.6.0'))
+    memory_cached = float(snmpget('1.3.6.1.4.1.2021.4.15.0'))
+    memory_unused = memory_avail + memory_cached
     memory_percent = 100 / memory_total * memory_unused
 
     if warning and warning > int(memory_percent):


### PR DESCRIPTION
The memory calculation should also count cached memory into unused memory, because cached memory will be freed when applications require it.