### PR TITLE
Handle pysnmp's `RequestTimedOut` exception more appropriately

### DIFF
--- a/check_synology.py
+++ b/check_synology.py
@@ -1,4 +1,5 @@
 from pysnmp.hlapi import *
+from pysnmp.proto.errind import RequestTimedOut
 import argparse
 import sys
 import math
@@ -30,6 +31,7 @@ critical = args.c
 state = 'OK'
 
 def snmpget(oid):
+    global state
     errorIndication, errorStatus, errorIndex, varBinds = next(
         getCmd(SnmpEngine(),
                UsmUserData(user_name, auth_key, priv_key, authProtocol=usmHMACMD5AuthProtocol, privProtocol=usmAesCfb128Protocol),
@@ -42,6 +44,9 @@ def snmpget(oid):
 
     if errorIndication:
         print(errorIndication)
+        if isinstance(errorIndication, RequestTimedOut):
+            state = "UNKNOWN"
+            exitCode()
     elif errorStatus:
         print('%s at %s' % (errorStatus.prettyPrint(),
                             errorIndex and varBinds[int(errorIndex) - 1][0] or '?'))


### PR DESCRIPTION
Dear Frederic,

thanks a stack for conceiving this fine program. We found that the code path when running into a `No SNMP response received before timeout` condition can be improved.

While we don't quite like how the patch is currently implemented, the code now handles this condition well. In this case, `check_synology` will respond with state "UNKNOWN".

With kind regards,
Andreas.

P.S.: For your reference, I am sharing two of the tracebacks we received below.

```python
Traceback (most recent call last):
  File "/opt/check_synology/check_synology.py", line 100, in if disk.startswith("No Such Instance"):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

```python
Traceback (most recent call last):
  File "/opt/check_synology/check_synology.py", line 67, in load1 = str(float(snmpget('1.3.6.1.4.1.2021.10.1.5.1'))/100)
TypeError: float() argument must be a string or a number, not 'NoneType'
```

/cc @tonkenfo
