### PR TITLE
Use "easysnmp" and "snmpwalk" for huge efficiency gains

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 This plugin uses ```snmpv3``` with ```MD5``` + ```AES``` to check a lot of different values on your Synology DiskStation.
 
-This check plugin needs ```pysnmp``` to be installed on your system. You can install it with: ```pip install easysnmp```
+This check plugin is based on ```easysnmp```, you can install it on your system with ```pip install easysnmp```.
+Note that ```easysnmp``` needs ```net-snmp```, so you might also need to install ```libsnmp-dev``` and 
+```snmp-mibs-downloader``` on your system, like ```apt install --yes libsnmp-dev```.
+
 
 Usage:
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin uses ```snmpv3``` with ```MD5``` + ```AES``` to check a lot of different values on your Synology DiskStation.
 
-This check plugin needs ```pysnmp``` to be installed on your system. You can install it with: ```pip3 install pysnmp```
+This check plugin needs ```pysnmp``` to be installed on your system. You can install it with: ```pip install easysnmp```
 
 Usage:
 ```
@@ -86,7 +86,7 @@ Make sure to set ```synology_snmp_user```, ```synology_snmp_autkey``` and ```syn
 
 If you want to add a missing check or another value to be added than you can use the [official Synology MIB Guide](https://global.download.synology.com/download/Document/MIBGuide/Synology_DiskStation_MIB_Guide.pdf) as a hint for the right MIBs / OIDs and start a pull-request.
 
-This plugin was tested successfully with DS215j and DS718+
+This plugin was tested successfully with DS215j, DS216+ and DS718+.
 
 Note: As of version 0.2 and higher only python3 is supported. Version 0.1 was the last python2 compatible release.
 

--- a/check_synology.py
+++ b/check_synology.py
@@ -6,7 +6,7 @@ import re
 import easysnmp
 
 AUTHOR = "Frederic Werner"
-VERSION = 0.2
+VERSION = "1.0.0"
 
 parser = argparse.ArgumentParser()
 parser.add_argument("hostname", help="the hostname", type=str)

--- a/check_synology.py
+++ b/check_synology.py
@@ -1,9 +1,9 @@
-from pysnmp.hlapi import *
-from pysnmp.proto.errind import RequestTimedOut
 import argparse
 import sys
 import math
 import re
+
+import easysnmp
 
 AUTHOR = "Frederic Werner"
 VERSION = 0.2
@@ -30,31 +30,36 @@ critical = args.c
 
 state = 'OK'
 
-def snmpget(oid):
-    global state
-    errorIndication, errorStatus, errorIndex, varBinds = next(
-        getCmd(SnmpEngine(),
-               UsmUserData(user_name, auth_key, priv_key, authProtocol=usmHMACMD5AuthProtocol, privProtocol=usmAesCfb128Protocol),
-               UdpTransportTarget((hostname, port)),
-               ContextData(),
-               ObjectType(ObjectIdentity(oid)
-                #.addAsn1MibSource('file:///usr/share/snmp', 'http://mibs.snmplabs.com/asn1/@mib@')
-                ))
-    )
+try:
+    session = easysnmp.Session(
+        hostname=hostname,
+        version=3,
+        security_level="auth_with_privacy",
+        security_username=user_name,
+        auth_password=auth_key,
+        auth_protocol="MD5",
+        privacy_password=priv_key,
+        privacy_protocol="AES128")
 
-    if errorIndication:
-        print(errorIndication)
-        if isinstance(errorIndication, RequestTimedOut):
-            state = "UNKNOWN"
-            exitCode()
-    elif errorStatus:
-        print('%s at %s' % (errorStatus.prettyPrint(),
-                            errorIndex and varBinds[int(errorIndex) - 1][0] or '?'))
-    else:
-        for varBind in varBinds:
-            #answer = (' = '.join([x.prettyPrint() for x in varBind]))
-            #print(' = '.join([x.prettyPrint() for x in varBind]))
-            return varBind[-1].prettyPrint()
+except easysnmp.EasySNMPError as e:
+    print(e)
+    exit(-1)
+
+def snmpget(oid):
+    try:
+        res = session.get(oid)
+        return res.value
+    except easysnmp.EasySNMPError as e:
+        print(e)
+
+# Walk the given OID and return all child OIDs as a list of tuples of OID and value
+def snmpwalk(oid):
+    res = []
+    try:
+        res = session.walk(oid)
+    except easysnmp.EasySNMPError as e:
+        print(e)
+    return res
 
 def exitCode():
     if state == 'OK':
@@ -98,13 +103,9 @@ if mode == 'disk':
     maxDisk = 0
     output = ''
     perfdata = '|'
-    for i in range(0, 64, 1):
-        disk = snmpget('1.3.6.1.4.1.6574.2.1.1.2.' + str(i))
-        if disk.startswith("No Such Instance"):
-            break
-        maxDisk = maxDisk + 1
-    for i in range(0, maxDisk, 1):
-        disk_name = snmpget('1.3.6.1.4.1.6574.2.1.1.2.' + str(i))
+    for item in snmpwalk('1.3.6.1.4.1.6574.2.1.1.2'):
+        i = item.oid.split('.')[-1]
+        disk_name = item.value
         disk_status_nr = snmpget('1.3.6.1.4.1.6574.2.1.1.5.' + str(i))
         disk_temp = snmpget('1.3.6.1.4.1.6574.2.1.1.6.' + str(i))
         status_translation = {
@@ -131,9 +132,10 @@ if mode == 'disk':
 if mode == 'storage':
     output = ''
     perfdata = '|'
-    for i in range(1,256,1):
-        storage_name = snmpget('1.3.6.1.2.1.25.2.3.1.3.' + str(i))
-        if re.match("/volume(?!.+/@docker.*)", storage_name) :
+    for item in snmpwalk('1.3.6.1.2.1.25.2.3.1.3'):
+        i = item.oid.split('.')[-1]
+        storage_name = item.value
+        if re.match("/volume(?!.+/@docker.*)", storage_name):
             allocation_units = snmpget('1.3.6.1.2.1.25.2.3.1.4.' + str(i))
             size = snmpget('1.3.6.1.2.1.25.2.3.1.5.' + str(i))
             used = snmpget('1.3.6.1.2.1.25.2.3.1.6.' + str(i))


### PR DESCRIPTION
Dear Frederic,

coming from https://github.com/wernerfred/check_synology/pull/4#discussion_r824540325, this is the patch rebased on current master. All credits and kudos go to @kainhofer - thank you!

> The switch to easynmp means that instead of ~90 seconds (~4 seconds per snmpget) the program now takes between 0.5 and 3 seconds to complete.

With kind regards,
Andreas.

/cc @tonkenfo