### PR TITLE
Improve configuration snippets for Icinga

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 A monitoring plugin for checking different values on a Synology DiskStation,
 compatible with Nagios and Icinga.
 
-The plugin was tested successfully with DS215j, DS216+ and DS718+ models.
-For communication, it uses `snmpv3` with `MD5` + `AES`.
+The plugin was tested successfully with DS214play, DS215j, DS216+, DS218 and
+DS718+ models. For communication, it uses `SNMPv3` with `MD5` + `AES`.
 
 If you want to add a missing check or another value, you are most welcome to
 submit a patch / pull request. As a reference for discovering the right

--- a/icinga2/synology-command.conf
+++ b/icinga2/synology-command.conf
@@ -1,10 +1,26 @@
-// `check_synology` `CheckCommand` definition for Icinga 2
+/**
+ *
+ * `check_synology` `CheckCommand` definition for Icinga 2
+ *
+ * For updates and contributions, head over to https://github.com/wernerfred/check_synology
+ *
+ * On a vanilla Debian installation of Nagios/Icinga, it will assume the
+ * program to be installed at `/usr/lib/nagios/plugins/check_synology`.
+ *
+ * If you installed it to a different location on your machine, just place a symlink like:
+ *
+ *    ln -s $(which check_synology) /usr/lib/nagios/plugins/check_synology
+ *
+ **/
 
 object CheckCommand "check_synology" {
+
+  import "plugin-check-command"
+
   command = [ PluginDir + "/check_synology" ]
 
   arguments = {
-    "--host" = {
+    "--hostname" = {
        skip_key = true
        order = 0
        value = "$synology_host$"
@@ -29,7 +45,16 @@ object CheckCommand "check_synology" {
        order = 4
        value = "$synology_mode$"
     }
-    "-w" = "$synology_warning$"
-    "-c" = "$synology_critical$"
+    "-w" = {
+       order = 5
+       set_if = "$synology_warning$"
+       value = "$synology_warning$"
+    }
+    "-c" = {
+       order = 6
+       set_if = "$synology_critical$"
+       value = "$synology_critical$"
+    }
   }
+
 }

--- a/icinga2/synology-host.conf
+++ b/icinga2/synology-host.conf
@@ -1,11 +1,39 @@
-// `check_synology` example host configuration snippet for Icinga 2
+/**
+ *
+ * `check_synology` example host configuration snippet for Icinga 2
+ *
+ * For updates and contributions, head over to https://github.com/wernerfred/check_synology
+ *
+ * The `Host` configuration object provided in this file is a blueprint configuration snippet
+ * to outline how the `check_synology` sensor can be configured on a host level.
+ *
+ * By toggling `vars.check_synology = true` or when `host.vars.os == "DSM"`,
+ * all `Service` configuration objects are activated. They provide reasonable default
+ * threshold values for raising WARNING/CRITICAL/UNKNOWN states and can be overwritten
+ * in the configuration section below.
+ *
+ **/
 
 object Host "foo.example.org" {
 
-  // Configuration section for `check_synology`
+  // Synology configuration.
+
+  // Connectivity information.
   vars.synology_host          = "synology.example.org"
   vars.synology_snmp_user     = "nagios"
   vars.synology_snmp_authkey  = "secret"
   vars.synology_snmp_privkey  = "secret"
+
+  // Optionally enable services on non-DSM hosts.
+  // Use this option when monitoring the appliance from another host.
+  // vars.check_synology         = true
+
+  // Optionally assign a human-readable label.
+  // vars.synology_location      = "ACME Corp."
+
+  // Optionally adjust warning / critical thresholds.
+  // Reasonable defaults are provided through `synology-services.conf`.
+  // vars.synology_load1_warning = 3
+  // vars.synology_load1_critical = 5
 
 }

--- a/icinga2/synology-services.conf
+++ b/icinga2/synology-services.conf
@@ -1,15 +1,132 @@
-// `check_synology` example service configuration snippet for Icinga 2
+/**
+ *
+ * `check_synology` full service configuration snippet for Icinga 2.
+ *
+ * For updates and contributions, head over to https://github.com/wernerfred/check_synology
+ *
+ * The `Service` configuration objects provided in this file can be used 1:1 and should not
+ * be modified. They try to provide reasonable default threshold values which can be
+ * overwritten within the `Host` configuration object.
+ *
+ * Finding the right thresholds that fit everyone is not possible. So, in general,
+ * the default values are more on the "better safe than sorry" side of the spectrum and
+ * should be reconfigured based on individual needs.
+ *
+ * This is specifically applicable to system and disk temperature metrics, as those are
+ * highly dependent on ambient temperature levels and vary hugely between regions on earth
+ * and/or temperature conditioning scenarios.
+ *
+ **/
 
-apply Service "syno-load" {
-  import "generic-service"
+// Baseline template. All service definitions will inherit this.
+template Service "synology-base" {
 
   check_command = "check_synology"
 
+  if (host.vars.synology_host) {
+    vars.synology_host = host.vars.synology_host
+  } else {
+    vars.synology_host = "$address$"
+  }
+
+  if (host.vars.synology_location) {
+    display_name += " at " + host.vars.synology_location
+  }
+
+  // Enable this to make the command run on the monitored host
+  // when different from the Icinga instance.
+  // command_endpoint   = host_name
+
+}
+
+apply Service "Synology CPU load" {
+  import "generic-service"
+  import "synology-base"
+
+  // WARNING/CRITICAL if CPU load average (1 minute) is higher than X.
+  // The default threshold values have been picked from the default Icinga 2
+  // configuration, see `/usr/share/icinga2/include/command-plugins.conf`.
   vars.synology_mode = "load"
-  vars.synology_host = "$address$"
+  vars.synology_warning = host.vars.synology_load1_warning || 5
+  vars.synology_critical = host.vars.synology_load1_critical || 10
 
-  vars.synology_warning = "$synology_load_w$"
-  vars.synology_critical = "$synology_load_c$"
+  assign where host.vars.check_synology == true || host.vars.os == "DSM"
+}
 
-  assign where host.vars.os == "DSM"
+apply Service "Synology system memory" {
+  import "generic-service"
+  import "synology-base"
+
+  // WARNING/CRITICAL if available/usable system memory is lower than %.
+  vars.synology_mode = "memory"
+  vars.synology_warning = host.vars.synology_memory_warning || 20
+  vars.synology_critical = host.vars.synology_memory_critical || 10
+
+  assign where host.vars.check_synology == true || host.vars.os == "DSM"
+}
+
+apply Service "Synology disk status" {
+  import "generic-service"
+  import "synology-base"
+
+  /*
+  CRITICAL when disk status is `SystemPartitionFailed` or `Crashed`.
+  WARNING/CRITICAL when disk drive temperature is higher than °C.
+
+  Official *Manufacturer Normal Internal Operating Ranges* are
+  0° – 65°C for HDD disks and 0°C to 70°C for SSD disks.
+
+  - https://www.hdsentinel.com/forum/viewtopic.php?f=32&t=1519
+  - https://mariushosting.com/whats-a-good-operating-temperature-for-my-synology/
+  */
+  vars.synology_mode = "disk"
+  vars.synology_warning = host.vars.synology_disktemp_warning || 43
+  vars.synology_critical = host.vars.synology_disktemp_critical || 50
+
+  assign where host.vars.check_synology == true || host.vars.os == "DSM"
+}
+
+apply Service "Synology disk space" {
+  import "generic-service"
+  import "synology-base"
+
+  // WARNING/CRITICAL if used disk space is higher than %.
+  vars.synology_mode = "storage"
+  vars.synology_warning = host.vars.synology_diskspace_warning || 90
+  vars.synology_critical = host.vars.synology_diskspace_critical || 95
+
+  // Needed to be adjusted to work against "Timeout exceeded" errors.
+  check_timeout = 120
+
+  // Check each 15 minutes.
+  check_interval = 900
+
+  assign where host.vars.check_synology == true || host.vars.os == "DSM"
+}
+
+apply Service "Synology update status" {
+  import "generic-service"
+  import "synology-base"
+
+  // OK if update status is "Unavailable".
+  // WARNING if update status is "Available".
+  // UNKNOWN otherwise.
+  vars.synology_mode = "update"
+
+  assign where host.vars.check_synology == true || host.vars.os == "DSM"
+}
+
+apply Service "Synology system status" {
+  import "generic-service"
+  import "synology-base"
+
+  // OK if all of the binary system status flags yield `Normal`.
+  // CRITICAL if any of the binary system status flags yields `Failed`.
+  // WARNING/CRITICAL if system temperature is higher than °C.
+  // https://www.tomshardware.com/how-to/how-to-monitor-cpu-temp-temperature
+  vars.synology_mode = "status"
+  vars.synology_warning = host.vars.synology_temperature_warning || 50
+  vars.synology_critical = host.vars.synology_temperature_critical || 60
+
+  assign where host.vars.check_synology == true || host.vars.os == "DSM"
 }


### PR DESCRIPTION
Dear Frederic,

in order to improve installation convenience further, this time on the »Icinga integration« side, the goal of this patch [^1] is to provide complete Icinga configuration resources which can be reused out of the box. We verified it by running it on our servers already, which was needed to adjust some further bits. We hope you like it.

### Features
- The configuration provides reasonable default threshold values (warning/critical) for the corresponding sensor modes.
  Please let me know if you think some of the default values can be improved.
- For addressing the Synology appliance, either `host.vars.synology_host` or `$address$` is used.
- With `host.vars.synology_location`, you can optionally provide a human-readable label to the monitored appliance.
  This will get reflected as suffix to the `display_name`.
- Optionally enable `command_endpoint = host_name` for running the check program on a different host.
- Beside `host.vars.os == "DSM"`, the check will also trigger on `host.vars.check_synology == true`.
  This is useful if the `Service` object is assigned to another, non-DSM, host.
- Provide reasonable inline documentation which describe the configuration parameters in more detail.

### Screenshot
![image](https://user-images.githubusercontent.com/453543/157996304-3790993d-03a1-4b82-8d8c-7b7872f0dba1.png)

With kind regards,
Andreas.

/cc @tonkenfo

[^1]: It is based upon my previous changes #20. For looking at the very diff right now instead of the PR which also includes the previous commits, 0b1eb8888c would be the right choice.
