### PR TITLE
Improve evaluation of trigger state for "update status" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A custom port can be specified by using `-p`. The default value is `161`.
 | memory  | Checks the physical installed memory (unused, cached and total)            | if less usable than w/c in %        |
 | disk    | Detects and checks all disks (name, status, temperature)                   | if temp higher than w/c in °C <br> if c is set it will also trigger if status <br> is Failure or Crashed                                                             |
 | storage | Detects and checks all disks (free, total, %)                              | if more used than w/c in %          |
-| update  | Shows the current DSM version and if DSM update is available               | set w/c to any int this triggers: <br> warning if available and critical <br> if other than un-/available                                                           |
+| update  | Shows the current DSM version and if DSM update is available               | if update is "Unavailable", will trigger OK <br> if update is "Available", will trigger WARNING <br> otherwise: UNKNOWN |
 | status  | Shows model, s/n, temp and status of system, fan, cpu fan and power supply | if temp higher than w/c in °C       |
 
 

--- a/check_synology.py
+++ b/check_synology.py
@@ -169,7 +169,7 @@ if mode == 'update':
 
     if warning and 1 == int(update_status_nr):
         state = 'WARNING'
-    if critical and [4|5] == int(update_status_nr):
+    if critical and int(update_status_nr) in [4, 5]:
         state = 'CRITICAL'
 
     update_status = status_translation.get(update_status_nr)

--- a/check_synology.py
+++ b/check_synology.py
@@ -166,13 +166,14 @@ if mode == 'update':
             '4': "Disconnected",
             '5': "Others"
         }
-
-    if warning and 1 == int(update_status_nr):
-        state = 'WARNING'
-    if critical and int(update_status_nr) in [4, 5]:
-        state = 'CRITICAL'
+    state_translation = {
+        '2': 'OK',
+        '1': 'WARNING',
+    }
 
     update_status = status_translation.get(update_status_nr)
+    state = state_translation.get(update_status_nr, "UNKNOWN")
+
     print(state + ' - DSM Version: %s, DSM Update: %s' % (update_dsm_verison, update_status), '| DSMupdate=%sc' % update_status_nr)
     exitCode()
 

--- a/check_synology.py
+++ b/check_synology.py
@@ -158,7 +158,7 @@ if mode == 'storage':
 
 if mode == 'update':
     update_status_nr = snmpget('1.3.6.1.4.1.6574.1.5.4.0')
-    update_dsm_verison = snmpget('1.3.6.1.4.1.6574.1.5.3.0')
+    update_dsm_version = snmpget('1.3.6.1.4.1.6574.1.5.3.0')
     status_translation = {
             '1': "Available",
             '2': "Unavailable",
@@ -174,7 +174,7 @@ if mode == 'update':
     update_status = status_translation.get(update_status_nr)
     state = state_translation.get(update_status_nr, "UNKNOWN")
 
-    print(state + ' - DSM Version: %s, DSM Update: %s' % (update_dsm_verison, update_status), '| DSMupdate=%sc' % update_status_nr)
+    print(state + ' - DSM Version: %s, DSM Update: %s' % (update_dsm_version, update_status), '| DSMupdate=%sc' % update_status_nr)
     exitCode()
 
 if mode == 'status':


### PR DESCRIPTION
Hi Frederic,

~~I believe this check to evaluate the `CRITICAL` status for the "status update" sensor might never have worked. This patch fixes it.~~

after reviewing the corresponding logic, it was considered to implement another proposal:

- OK: Unavailable
- WARNING: Available
- UNKNOWN: Connecting, Disconnected, Others (all other states)

In this way, there will be no `CRITICAL` state on this mode at all.

With kind regards,
Andreas.