### PR TITLE
Improve error message when SNMP connection fails by including hostname

### DIFF
--- a/check_synology.py
+++ b/check_synology.py
@@ -42,7 +42,7 @@ try:
         privacy_protocol="AES128")
 
 except easysnmp.EasySNMPError as e:
-    print(e)
+    print("Could not connect to SNMP at {}. Reason: {}".format(hostname, e))
     exit(-1)
 
 def snmpget(oid):


### PR DESCRIPTION
Dear Frederic,

based on the last comment of our discussion over at https://github.com/wernerfred/check_synology/pull/20#discussion_r825302032, I figured it would be a good idea to actually try to connect to a hostname which does not resolve.

With this patch, `check_synology` responds with
```
Could not connect to SNMP at synology.example.org. Reason: couldn't create SNMP handle
```

This allows the user to more easily figure out to put in a correct address there.

With kind regards,
Andreas.
