### PR TITLE
feat: Fix and improve state evaluation for "disk status" check

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A custom port can be specified by using `-p`. The default value is `161`.
 | :-----: | -------------------------------------------------------------------------- | ----------------------------------- |
 | load    | Checks the load1, load5 and load15 values                                  | if more than w/c in int (only load1)|
 | memory  | Checks the physical installed memory (unused, cached and total)            | if less usable than w/c in %        |
-| disk    | Detects and checks all disks (name, status, temperature)                   | if temp higher than w/c in °C <br> if c is set it will also trigger if status <br> is Failure or Crashed                                                             |
+| disk    | Detects and checks all disks (status, temperature)                         | if status is "SystemPartitionFailed" or "Crashed", will trigger CRITICAL <br> if temperature is higher than w/c in °C, will trigger WARNING/CRITICAL |
 | storage | Detects and checks all disks (free, total, %)                              | if more used than w/c in %          |
 | update  | Shows the current DSM version and if DSM update is available               | if update is "Unavailable", will trigger OK <br> if update is "Available", will trigger WARNING <br> otherwise: UNKNOWN |
 | status  | Shows model, s/n, temp and status of system, fan, cpu fan and power supply | if temp higher than w/c in °C       |


### PR DESCRIPTION
Dear Frederic,

it's me again ;]. While looking at the code in more detail, we discovered a minor flaw and thought it would be a good idea to submit a patch. Beforehand, the code would only detect disk status `SystemPartitionFailed`, while `Crashed` would have been missed.

After fixing that, the code has been expanded to offer a more general approach for converging sensor states of *multiple* items (here: disks) into a single outcome state. Now, the state evaluation flow is more linear and can easily be reused for all other checks involving multiple items. We hope you like it.

With kind regards,
Andreas.