### PR TITLE
fix: Improve error handling when monitored appliance is not available

### DIFF
--- a/check_synology.py
+++ b/check_synology.py
@@ -32,6 +32,16 @@ critical = args.c
 
 state = 'OK'
 
+def croak(message=None):
+    """
+    Exit program with `UNKNOWN` state and error message.
+    """
+    global state
+    state = 'UNKNOWN'
+    message = message and str(message) or "unknown error"
+    print('%s - %s' % (state, message))
+    exitCode()
+
 try:
     session = easysnmp.Session(
         hostname=hostname,
@@ -43,24 +53,28 @@ try:
         privacy_password=priv_key,
         privacy_protocol="AES128")
 
-except easysnmp.EasySNMPError as e:
-    print("Could not connect to SNMP at {}. Reason: {}".format(hostname, e))
-    exit(-1)
+except Exception as e:
+    croak(e)
 
 def snmpget(oid):
+    """
+    Return value from single OID.
+    """
     try:
         res = session.get(oid)
         return res.value
-    except easysnmp.EasySNMPError as e:
-        print(e)
+    except Exception as e:
+        croak(e)
 
-# Walk the given OID and return all child OIDs as a list of tuples of OID and value
 def snmpwalk(oid):
+    """
+    Walk the given OID and return all child OIDs as a list of tuples of OID and value.
+    """
     res = []
     try:
         res = session.walk(oid)
-    except easysnmp.EasySNMPError as e:
-        print(e)
+    except Exception as e:
+        croak(e)
     return res
 
 def exitCode():

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     py_modules=["check_synology"],
     entry_points={"console_scripts": ["check_synology = check_synology"]},
     python_requires=">=3.4",
-    install_requires=["easysnmp>=0.2,<1"],
+    install_requires=["easysnmp>=0.2.6,<1"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: GNU Affero General Public License v3",


### PR DESCRIPTION
Dear Frederic,

this patch aims to improve robustness of non-happy code paths after bringing in #19 the other day.

Previously, the program yielded the rather cryptic error message `<built-in function get> returned NULL without setting an error` and also added a traceback, not catching the exception.

Now, any such exceptions are caught and cleanly converged into the `UNKNOWN` state, so that the program croaks with:

    UNKNOWN - timed out while connecting to remote host

**Note:** The improved error message will only be available when installing the latest [`easysnmp`] from the upstream repository.

With kind regards,
Andreas.

[`easysnmp`]: https://github.com/kamakazikamikaze/easysnmp


### Before
How it looked like on my aNag when the appliance went down.

![image](https://user-images.githubusercontent.com/453543/163597197-719da7e2-f48c-4ce8-a26a-4c6ea422f335.png)


### After

Now it looks compact and clean again.

![image](https://user-images.githubusercontent.com/453543/163597220-77b26e9f-240c-4ef2-8787-6a8509aeb20e.png)

With all six sensors active, the space-saving is even more dramatic and obvious. And of course, the error message is way clearer than before.

![image](https://user-images.githubusercontent.com/453543/163597653-1a62f131-bc5a-4eb4-87b2-e4341a1ccf36.png)
