### PR TITLE
Fix disk state evaluation and add the shebang line

### DIFF
--- a/check_synology.py
+++ b/check_synology.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import sys
 import math

--- a/check_synology.py
+++ b/check_synology.py
@@ -142,15 +142,15 @@ if mode == 'disk':
 
         # 3.a Evaluate list of disk status flag.
         if disk_status in ["Normal"]:
-            states += 'OK'
+            states.append('OK')
         elif disk_status in ["SystemPartitionFailed", "Crashed"]:
-            states += 'CRITICAL'
+            states.append('CRITICAL')
 
         # 3.b Evaluate disk temperature thresholds.
         if warning and warning < int(disk_temp):
-            states += 'WARNING'
+            states.append('WARNING')
         if critical and critical < int(disk_temp):
-            states += 'CRITICAL'
+            states.append('CRITICAL')
 
     # 4. Compute outcome for overall sensor state.
     state = 'UNKNOWN'


### PR DESCRIPTION
Hi

Disk state fix:
adding the disk states with `+=` results in an Array of single letters. Therefore the final disk state was in every case "UNKOWN". With `states.append()` it works as intended.

Shebang:
The script was not automatically execute on my servers without the shebang

Regards Thomas