### PR TITLE
Fix typo in synology-host.conf

### DIFF
--- a/icinga2/synology-host.conf
+++ b/icinga2/synology-host.conf
@@ -7,7 +7,7 @@
  * The `Host` configuration object provided in this file is a blueprint configuration snippet
  * to outline how the `check_synology` sensor can be configured on a host level.
  *
- * By toggling `vars.check_synology = true` or when `host.vars.os == "DSM"`,
+ * By toggling `vars.check_synology = true` or when `vars.os = "DSM"`,
  * all `Service` configuration objects are activated. They provide reasonable default
  * threshold values for raising WARNING/CRITICAL/UNKNOWN states and can be overwritten
  * in the configuration section below.


### PR DESCRIPTION
At that place, host.vars.os == "DSM" should be vars.os = "DSM"