### PR TITLE
snmp-port

### DIFF
--- a/check_synology.py
+++ b/check_synology.py
@@ -49,6 +49,7 @@ def croak(message=None):
 try:
     session = easysnmp.Session(
         hostname=hostname,
+        remote_port=port,
         version=3,
         timeout=snmp_timeout,
         retries=snmp_retries,


### PR DESCRIPTION
Added the ability to transmit the user defined port to easysnmp. Which gives you the ability to define it as a new argument/field in icinga director.