### PR TITLE
Update check_synology.py

### DIFF
--- a/check_synology.py
+++ b/check_synology.py
@@ -138,7 +138,7 @@ if mode == 'disk':
     output = ''
     perfdata = '|'
     for item in snmpwalk('1.3.6.1.4.1.6574.2.1.1.2'):
-        i = item.oid.split('.')[-1]
+        i = item.oid_index or item.oid.split('.')[-1]
         disk_name = item.value
         disk_status_nr = snmpget('1.3.6.1.4.1.6574.2.1.1.5.' + str(i))
         disk_temp = snmpget('1.3.6.1.4.1.6574.2.1.1.6.' + str(i))
@@ -190,7 +190,7 @@ if mode == 'storage':
     output = ''
     perfdata = '|'
     for item in snmpwalk('1.3.6.1.2.1.25.2.3.1.3'):
-        i = item.oid.split('.')[-1]
+        i = item.oid_index or item.oid.split('.')[-1]
         storage_name = item.value
         if re.match("/volume(?!.+/@docker.*)", storage_name):
             allocation_units = snmpget('1.3.6.1.2.1.25.2.3.1.4.' + str(i))


### PR DESCRIPTION
When running snmpwalk on synology server v7.2-64570, the `item.oid` returns the name instead of string on some calls.

Expected:
`<SNMPVariable value='/volume1' (oid='iso.3.6.1.2.1.25.2.3.1.3.53', oid_index='', snmp_type='OCTETSTR')>`

Received:
`<SNMPVariable value='/volume1' (oid='hrStorageDescr', oid_index='53', snmp_type='OCTETSTR')>`

Fixed code to use `oid_index` or the `oid`