### PR TITLE
Added raid mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Custom timeouts (`-t`) and retries (`-r`) can be specified by using `-t` and `-r
 | storage | Detects and checks all disks (free, total, %)                              | if more used than w/c in %                                                                                                                                                                                                                                                        |
 | update  | Shows the current DSM version and if DSM update is available               | if update is "Unavailable", will trigger OK <br> if update is "Available", will trigger WARNING <br> otherwise: UNKNOWN                                                                                                                                                           |
 | status  | Shows model, s/n, temp and status of system, fan, cpu fan and power supply | if temp higher than w/c in °C                                                                                                                                                                                                                                                     |
-
+| raid  | Shows raid volume status | if status is 4-10 will trigger WARNING, any other values will be CRITICAL                                                                                                                                                                                                                                                |
 
 
 ## Example check


### PR DESCRIPTION
The current script will not show errors when raid status is in bad state, only when the drives are bad. This pull request will add raid checks. Here are a few examples of the script running:

```
# raid is re-syncing
python check_synology.py host pass pass2 raid
WARNING - raid status: [Storage Pool 3] status=7 | "Volume 3"=7

# raid is degraed
CRITICAL - raid status: [Storage Pool 3] 1 - raid status: [Storage Pool 1] 11 | "Storage Pool 3"=11 "Storage Pool 1"=1
```